### PR TITLE
Install correct package name on 21.04

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -85,7 +85,13 @@ fi
 fancy_message info "Updating"
 sudo apt-get update
 fancy_message info "Installing packages"
-sudo apt-get install -qq -y {curl,wget,stow,python-pygments}
+
+grep -q 21.04 /etc/issue
+if [[ "$?" == "0" ]]; then
+  sudo apt-get install -qq -y {curl,wget,stow,python3-pygments}  
+else
+  sudo apt-get install -qq -y {curl,wget,stow,python-pygments}
+fi
 
 unset PACSTALL_DIRECTORY
 export PACSTALL_DIRECTORY="/usr/share/pacstall"


### PR DESCRIPTION
Seems like you *removed* a snippet like this before? For my machine, `python3-pygments` was the correct name. So I'm hoping this is a fix for anyone else on 21.04