### PR TITLE
fix echo redirection as root user 

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -76,7 +76,7 @@ sudo mkdir -p $PACSTALL_DIRECTORY/repo
 sudo mkdir -p /var/log/pacstall_orphaned
 sudo rm $PACSTALL_DIRECTORY/repo/pacstallrepo.txt
 sudo touch $PACSTALL_DIRECTORY/repo/pacstallrepo.txt
-sudo echo "Henryws/pacstall-programs" > $PACSTALL_DIRECTORY/repo/pacstallrepo.txt
+sudo sh -c "echo 'Henryws/pacstall-programs' > $PACSTALL_DIRECTORY/repo/pacstallrepo.txt"
 sudo rm -rf /var/log/pacstall_installed
 sudo mkdir /var/log/pacstall_installed
 sudo rm -rf /var/cache/pacstall


### PR DESCRIPTION
- changed `sudo echo` to `sudo sh -c "echo"` to correctly redirect `STDOUT` to file as root user.