### PR TITLE
Set missed full path for ls in fish completion script

### DIFF
--- a/misc/completion/fish
+++ b/misc/completion/fish
@@ -44,4 +44,4 @@ complete -f --command pacstall -n "__fish_seen_subcommand_from -S" -a "(curl -s 
 complete -f --command pacstall -n "__fish_seen_subcommand_from -R" -a "(/bin/ls -1aA /usr/src/pacstall/ | tr ' ' '\n')"
 
 # Completion for the -Qi flag
-complete -f --command pacstall -n "__fish_seen_subcommand_from -Qi" -a "(ls -1aA /var/log/pacstall_installed | tr ' ' '\n')"
+complete -f --command pacstall -n "__fish_seen_subcommand_from -Qi" -a "(/bin/ls -1aA /var/log/pacstall_installed | tr ' ' '\n')"


### PR DESCRIPTION
`-Qi` flag in the fish complete script was missing the full path to `/bin/ls`.